### PR TITLE
FIX: Include user in guardian for serializer for a test

### DIFF
--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -1,9 +1,9 @@
-require 'rails_helper'
+require "rails_helper"
 
 describe CurrentUserSerializer do
   let(:user) { Fabricate(:user) }
   let :serializer do
-    CurrentUserSerializer.new(user, scope: Guardian.new, root: false)
+    CurrentUserSerializer.new(user, scope: Guardian.new(user), root: false)
   end
 
   before do
@@ -23,5 +23,4 @@ describe CurrentUserSerializer do
     expect(payload[:email]).not_to be_present
     expect(payload[:intercom_hash]).not_to be_present
   end
-
 end


### PR DESCRIPTION
Since chat is now a core plugin and turned on by default, it is causing the CurrentUserSerializer to need guardian initialized with a user.

```
 1) CurrentUserSerializer should add current user email and intercom hash
     Failure/Error: payload = serializer.as_json
     
     NoMethodError:
       undefined method `id' for nil:NilClass
     # ./plugins/chat/lib/chat/channel_fetcher.rb:137:in `secured_public_channel_search'
```